### PR TITLE
Linux support

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "5.0.9",
+      "commands": [
+        "dotnet-ef"
+      ]
+    }
+  }
+}

--- a/Server.csproj
+++ b/Server.csproj
@@ -3,6 +3,19 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+    <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows> 
+    <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX> 
+    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux> 
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsWindows)'=='true'">
+    <DefineConstants>Windows</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(IsOSX)'=='true'">
+    <DefineConstants>OSX</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(IsLinux)'=='true'">
+    <DefineConstants>Linux</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Console/Logger.cs
+++ b/src/Console/Logger.cs
@@ -88,10 +88,12 @@ namespace GameServer.Logging
             CommandHistory = new();
             TextField = new();
 
+            #if Windows
             Terminal.DisableMinimize();
             Terminal.DisableMaximize();
             Terminal.DisableResize();
             Terminal.DisableConsoleFeatures();
+            #endif
 
             TextField.row = 1; // Keep the text field 1 row ahead of the logged messages
 

--- a/src/Console/Terminal.cs
+++ b/src/Console/Terminal.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if Windows
+using System;
 using System.Runtime.InteropServices;
 
 namespace GameServer.Logging
@@ -109,3 +110,4 @@ namespace GameServer.Logging
         }
     }
 }
+#endif

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -12,6 +12,13 @@ namespace GameServer
         {
             StartLogger();
             StartServer();
+            #if Linux 
+            Logger.Log("Built on Linux!"); 
+            #elif OSX 
+            Logger.Log("Built on macOS!"); 
+            #elif Windows 
+            Logger.Log("Built in Windows!"); 
+            #endif
         }
 
         private static void StartLogger() 


### PR DESCRIPTION
I stopped `[DllImport("kernel32.dll")]` code from compiling on non-windows platforms (console resizing works fine with my default `pop os` console)  - platform detection provided by https://blog.magnusmontin.net/2018/11/05/platform-conditional-compilation-in-net-core/ . 

I also generated some random json when installing `dotnet ef`.

This allows developers to use linux as well as having cheaper and more readily available hosting for when the server is deployed.